### PR TITLE
Use opaque handles for C API table function filters

### DIFF
--- a/src/include/duckdb/main/capi/header_generation/functions/table_function_init.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function_init.json
@@ -102,6 +102,117 @@
             }
         },
         {
+            "name": "duckdb_init_get_filter_count",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Returns the number of filters that were pushed into the table function.\n\nThe returned filters can be inspected through `duckdb_init_get_filter`. Only filters using the comparison operators `=`, `!=`, `>`, `<`, `>=`, and `<=` are reported through this interface.\n\n",
+                "param_comments": {
+                    "info": "The info object"
+                },
+                "return_value": "The number of pushed filters supported by the C API."
+            }
+        },
+        {
+            "name": "duckdb_init_get_filter",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "filter_index"
+                },
+                {
+                    "type": "duckdb_table_function_filter *",
+                    "name": "out_filter"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the pushed filter at the specified index.\n\nThe index must be smaller than the value returned by `duckdb_init_get_filter_count`. The returned filter handle must be destroyed with `duckdb_destroy_table_function_filter` when it is no longer needed. Use `duckdb_table_function_filter_get_column_index`, `duckdb_table_function_filter_get_operator`, and `duckdb_table_function_filter_get_constant` to inspect the filter properties. The value returned by `duckdb_table_function_filter_get_constant` must be destroyed with `duckdb_destroy_value` when it is no longer needed.\n\n",
+                "param_comments": {
+                    "info": "The info object",
+                    "filter_index": "The index of the filter to fetch, from 0..duckdb_init_get_filter_count(info)",
+                    "out_filter": "The output filter handle."
+                },
+                "return_value": "`DuckDBSuccess` on success or `DuckDBError` if the filter index is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_column_index",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the column index the pushed filter applies to.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The column index of the filter or 0 if the handle is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_operator",
+            "return_type": "duckdb_table_filter_operator",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the comparison operator of the pushed filter.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The comparison operator of the filter. Returns `DUCKDB_TABLE_FILTER_OPERATOR_INVALID` if the handle is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_constant",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the constant value the pushed filter compares against.\n\nThe returned value must be destroyed with `duckdb_destroy_value` when it is no longer needed.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The constant value of the filter."
+            }
+        },
+        {
+            "name": "duckdb_destroy_table_function_filter",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter *",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Destroys the given table function filter handle.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle to destroy."
+                }
+            }
+        },
+        {
             "name": "duckdb_init_set_max_threads",
             "return_type": "void",
             "params": [

--- a/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
@@ -227,6 +227,27 @@
             }
         },
         {
+            "name": "duckdb_table_function_supports_filter_pushdown",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_table_function",
+                    "name": "table_function"
+                },
+                {
+                    "type": "bool",
+                    "name": "pushdown"
+                }
+            ],
+            "comment": {
+                "description": "Sets whether or not the given table function supports filter pushdown.\n\nIf this is set to true, the system will provide filters that can be inspected in the `init` stage through the `duckdb_init_get_filter_count` and `duckdb_init_get_filter` functions.\nIf this is set to false (the default), the system will apply filters after the table function has produced its data.\n\n",
+                "param_comments": {
+                    "table_function": "The table function",
+                    "pushdown": "True if the table function supports filter pushdown, false otherwise."
+                }
+            }
+        },
+        {
             "name": "duckdb_register_table_function",
             "return_type": "duckdb_state",
             "params": [

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
 
 namespace duckdb {
 
@@ -104,15 +106,25 @@ struct CTableInternalInitInfo {
 };
 
 struct CTableInternalFunctionInfo {
-	CTableInternalFunctionInfo(const CTableBindData &bind_data, CTableInitData &init_data, CTableInitData &local_data)
-	    : bind_data(bind_data), init_data(init_data), local_data(local_data), success(true) {
-	}
+        CTableInternalFunctionInfo(const CTableBindData &bind_data, CTableInitData &init_data, CTableInitData &local_data)
+            : bind_data(bind_data), init_data(init_data), local_data(local_data), success(true) {
+        }
 
-	const CTableBindData &bind_data;
-	CTableInitData &init_data;
-	CTableInitData &local_data;
-	bool success;
-	string error;
+        const CTableBindData &bind_data;
+        CTableInitData &init_data;
+        CTableInitData &local_data;
+        bool success;
+        string error;
+};
+
+struct CTableConstantFilter {
+        CTableConstantFilter(idx_t column_index, ExpressionType comparison_type, const Value &constant)
+            : column_index(column_index), comparison_type(comparison_type), constant(constant) {
+        }
+
+        idx_t column_index;
+        ExpressionType comparison_type;
+        Value constant;
 };
 
 //===--------------------------------------------------------------------===//
@@ -147,7 +159,78 @@ duckdb::CTableInternalFunctionInfo &GetCTableFunctionInfo(duckdb_function_info i
 }
 
 duckdb_function_info ToCTableFunctionInfo(duckdb::CTableInternalFunctionInfo &info) {
-	return reinterpret_cast<duckdb_function_info>(&info);
+        return reinterpret_cast<duckdb_function_info>(&info);
+}
+
+static duckdb::CTableConstantFilter *GetCTableFunctionFilter(duckdb_table_function_filter filter) {
+        return reinterpret_cast<duckdb::CTableConstantFilter *>(filter);
+}
+
+static duckdb_table_function_filter ToCTableFunctionFilter(duckdb::CTableConstantFilter *filter) {
+        return reinterpret_cast<duckdb_table_function_filter>(filter);
+}
+
+static bool ExpressionTypeToFilterOperator(ExpressionType type, duckdb_table_filter_operator &result) {
+        switch (type) {
+        case ExpressionType::COMPARE_EQUAL:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_EQUAL;
+                return true;
+        case ExpressionType::COMPARE_NOTEQUAL:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_NOT_EQUAL;
+                return true;
+        case ExpressionType::COMPARE_GREATERTHAN:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN;
+                return true;
+        case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN_OR_EQUAL;
+                return true;
+        case ExpressionType::COMPARE_LESSTHAN:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN;
+                return true;
+        case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN_OR_EQUAL;
+                return true;
+        default:
+                result = DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+                return false;
+        }
+}
+
+static void ExtractFiltersFromTableFilter(idx_t column_index, const TableFilter &filter,
+                                          vector<CTableConstantFilter> &out) {
+        switch (filter.filter_type) {
+        case TableFilterType::CONSTANT_COMPARISON: {
+                auto &constant_filter = filter.Cast<ConstantFilter>();
+                duckdb_table_filter_operator op;
+                if (ExpressionTypeToFilterOperator(constant_filter.comparison_type, op)) {
+                        out.emplace_back(column_index, constant_filter.comparison_type, constant_filter.constant);
+                }
+                return;
+        }
+        case TableFilterType::CONJUNCTION_AND: {
+                auto &and_filter = filter.Cast<ConjunctionAndFilter>();
+                for (auto &child : and_filter.child_filters) {
+                        ExtractFiltersFromTableFilter(column_index, *child, out);
+                }
+                return;
+        }
+        default:
+                return;
+        }
+}
+
+static vector<CTableConstantFilter> ExtractFilters(optional_ptr<TableFilterSet> filters) {
+        vector<CTableConstantFilter> result;
+        if (!filters) {
+                return result;
+        }
+        for (auto &entry : filters->filters) {
+                if (!entry.second) {
+                        continue;
+                }
+                ExtractFiltersFromTableFilter(entry.first, *entry.second, result);
+        }
+        return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -314,18 +397,26 @@ void duckdb_table_function_set_function(duckdb_table_function table_function, du
 }
 
 void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown) {
-	if (!table_function) {
-		return;
-	}
-	auto &tf = GetCTableFunction(table_function);
-	tf.projection_pushdown = pushdown;
+        if (!table_function) {
+                return;
+        }
+        auto &tf = GetCTableFunction(table_function);
+        tf.projection_pushdown = pushdown;
+}
+
+void duckdb_table_function_supports_filter_pushdown(duckdb_table_function table_function, bool pushdown) {
+        if (!table_function) {
+                return;
+        }
+        auto &tf = GetCTableFunction(table_function);
+        tf.filter_pushdown = pushdown;
 }
 
 duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb_table_function function) {
-	if (!connection || !function) {
-		return DuckDBError;
-	}
-	auto con = reinterpret_cast<duckdb::Connection *>(connection);
+        if (!connection || !function) {
+                return DuckDBError;
+        }
+        auto con = reinterpret_cast<duckdb::Connection *>(connection);
 	auto &tf = GetCTableFunction(function);
 	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
 
@@ -500,21 +591,98 @@ idx_t duckdb_init_get_column_count(duckdb_init_info info) {
 }
 
 idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index) {
-	if (!info) {
-		return 0;
-	}
-	auto &init_info = GetCInitInfo(info);
-	if (column_index >= init_info.column_ids.size()) {
-		return 0;
-	}
-	return init_info.column_ids[column_index];
+        if (!info) {
+                return 0;
+        }
+        auto &init_info = GetCInitInfo(info);
+        if (column_index >= init_info.column_ids.size()) {
+                return 0;
+        }
+        return init_info.column_ids[column_index];
+}
+
+idx_t duckdb_init_get_filter_count(duckdb_init_info info) {
+        if (!info) {
+                return 0;
+        }
+        auto &init_info = GetCInitInfo(info);
+        auto filters = ExtractFilters(init_info.filters);
+        return filters.size();
+}
+
+duckdb_state duckdb_init_get_filter(duckdb_init_info info, idx_t filter_index, duckdb_table_function_filter *out_filter) {
+        if (!info || !out_filter) {
+                return DuckDBError;
+        }
+        *out_filter = nullptr;
+
+        auto &init_info = GetCInitInfo(info);
+        auto filters = ExtractFilters(init_info.filters);
+        if (filter_index >= filters.size()) {
+                return DuckDBError;
+        }
+        auto &filter = filters[filter_index];
+        duckdb_table_filter_operator filter_type;
+        if (!ExpressionTypeToFilterOperator(filter.comparison_type, filter_type)) {
+                return DuckDBError;
+        }
+
+        auto *filter_handle = new duckdb::CTableConstantFilter(filter.column_index, filter.comparison_type, filter.constant);
+        *out_filter = ToCTableFunctionFilter(filter_handle);
+        return DuckDBSuccess;
+}
+
+idx_t duckdb_table_function_filter_get_column_index(duckdb_table_function_filter filter) {
+        if (!filter) {
+                return 0;
+        }
+        auto *internal = GetCTableFunctionFilter(filter);
+        if (!internal) {
+                return 0;
+        }
+        return internal->column_index;
+}
+
+duckdb_table_filter_operator duckdb_table_function_filter_get_operator(duckdb_table_function_filter filter) {
+        if (!filter) {
+                return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+        }
+        auto *internal = GetCTableFunctionFilter(filter);
+        if (!internal) {
+                return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+        }
+        duckdb_table_filter_operator result;
+        if (!ExpressionTypeToFilterOperator(internal->comparison_type, result)) {
+                return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+        }
+        return result;
+}
+
+duckdb_value duckdb_table_function_filter_get_constant(duckdb_table_function_filter filter) {
+        if (!filter) {
+                return nullptr;
+        }
+        auto *internal = GetCTableFunctionFilter(filter);
+        if (!internal) {
+                return nullptr;
+        }
+        return reinterpret_cast<duckdb_value>(new Value(internal->constant));
+}
+
+void duckdb_destroy_table_function_filter(duckdb_table_function_filter *filter) {
+        if (!filter || !*filter) {
+                return;
+        }
+        auto *internal = GetCTableFunctionFilter(*filter);
+        delete internal;
+        *filter = nullptr;
 }
 
 void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads) {
-	if (!info) {
-		return;
-	}
-	auto &init_info = GetCInitInfo(info);
+        if (!info) {
+                return;
+        }
+        auto &init_info = GetCInitInfo(info);
 	init_info.init_data.max_threads = max_threads;
 }
 

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -1,5 +1,7 @@
 #include "capi_tester.hpp"
 
+#include <vector>
+
 using namespace duckdb;
 using namespace std;
 
@@ -319,4 +321,116 @@ TEST_CASE("Table function client context return") {
 	REQUIRE(result->Fetch<int64_t>(1, 0) == 42);
 	REQUIRE(result->Fetch<int64_t>(1, 1) == 42);
 	REQUIRE(result->Fetch<int64_t>(1, 2) == 42);
+}
+
+struct capi_filter_pushdown_info {
+        idx_t column_index;
+        duckdb_table_filter_operator op;
+        int64_t constant;
+};
+
+static std::vector<capi_filter_pushdown_info> capi_last_filters;
+static idx_t capi_last_filter_count = 0;
+
+void capi_filter_pushdown_bind(duckdb_bind_info info) {
+        duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+        duckdb_bind_add_result_column(info, "value", type);
+        duckdb_destroy_logical_type(&type);
+}
+
+void capi_filter_pushdown_init(duckdb_init_info info) {
+        capi_last_filters.clear();
+        capi_last_filter_count = duckdb_init_get_filter_count(info);
+        for (idx_t i = 0; i < capi_last_filter_count; i++) {
+                duckdb_table_function_filter filter;
+                REQUIRE(duckdb_init_get_filter(info, i, &filter) == DuckDBSuccess);
+                REQUIRE(filter);
+
+                capi_filter_pushdown_info entry;
+                entry.column_index = duckdb_table_function_filter_get_column_index(filter);
+                entry.op = duckdb_table_function_filter_get_operator(filter);
+                duckdb_value constant = duckdb_table_function_filter_get_constant(filter);
+                REQUIRE(constant);
+                entry.constant = duckdb_get_int64(constant);
+                duckdb_destroy_value(&constant);
+                duckdb_destroy_table_function_filter(&filter);
+                capi_last_filters.push_back(entry);
+        }
+}
+
+void capi_filter_pushdown_function(duckdb_function_info info, duckdb_data_chunk output) {
+        auto vec = duckdb_data_chunk_get_vector(output, 0);
+        auto data = static_cast<int64_t *>(duckdb_vector_get_data(vec));
+        for (idx_t i = 0; i < 10; i++) {
+                data[i] = static_cast<int64_t>(i);
+        }
+        duckdb_data_chunk_set_size(output, 10);
+}
+
+static void capi_register_filter_pushdown_function(duckdb_connection connection, const char *name) {
+        auto function = duckdb_create_table_function();
+        duckdb_table_function_set_name(function, name);
+        duckdb_table_function_set_bind(function, capi_filter_pushdown_bind);
+        duckdb_table_function_set_init(function, capi_filter_pushdown_init);
+        duckdb_table_function_set_function(function, capi_filter_pushdown_function);
+        duckdb_table_function_supports_projection_pushdown(function, true);
+        duckdb_table_function_supports_filter_pushdown(function, true);
+        REQUIRE(duckdb_register_table_function(connection, function) == DuckDBSuccess);
+        duckdb_destroy_table_function(&function);
+}
+
+TEST_CASE("Table function filter pushdown via C API") {
+        CAPITester tester;
+        duckdb::unique_ptr<CAPIResult> result;
+
+        REQUIRE(tester.OpenDatabase(nullptr));
+        capi_register_filter_pushdown_function(tester.connection, "capi_filter_pushdown");
+
+        struct ExpectedFilter {
+                duckdb_table_filter_operator op;
+                int64_t constant;
+        };
+
+        struct QueryExpectation {
+                const char *query;
+                std::vector<ExpectedFilter> expected_filters;
+        };
+
+        std::vector<QueryExpectation> expectations = {
+            {"SELECT * FROM capi_filter_pushdown() WHERE value = 5", {{DUCKDB_TABLE_FILTER_OPERATOR_EQUAL, 5}}},
+            {"SELECT * FROM capi_filter_pushdown() WHERE value != 3", {{DUCKDB_TABLE_FILTER_OPERATOR_NOT_EQUAL, 3}}},
+            {"SELECT * FROM capi_filter_pushdown() WHERE value > 7", {{DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN, 7}}},
+            {"SELECT * FROM capi_filter_pushdown() WHERE value >= 8", {{DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN_OR_EQUAL, 8}}},
+            {"SELECT * FROM capi_filter_pushdown() WHERE value < 4", {{DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN, 4}}},
+            {"SELECT * FROM capi_filter_pushdown() WHERE value <= 6", {{DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN_OR_EQUAL, 6}}},
+            {"SELECT * FROM capi_filter_pushdown() WHERE value BETWEEN 2 AND 6",
+             {{DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN_OR_EQUAL, 2},
+              {DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN_OR_EQUAL, 6}}}
+        };
+
+        for (auto &expectation : expectations) {
+                capi_last_filters.clear();
+                capi_last_filter_count = 0;
+
+                result = tester.Query(expectation.query);
+                REQUIRE_NO_FAIL(*result);
+
+                REQUIRE(capi_last_filter_count == expectation.expected_filters.size());
+                REQUIRE(capi_last_filters.size() == expectation.expected_filters.size());
+
+                for (auto &filter_info : capi_last_filters) {
+                        REQUIRE(filter_info.column_index == 0);
+                }
+
+                for (auto &expected : expectation.expected_filters) {
+                        bool found_match = false;
+                        for (auto &captured : capi_last_filters) {
+                                if (captured.op == expected.op && captured.constant == expected.constant) {
+                                        found_match = true;
+                                        break;
+                                }
+                        }
+                        REQUIRE(found_match);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- represent `duckdb_table_function_filter` as an opaque handle with dedicated accessor and destroy functions
- update the C API bridge to allocate filter handles and expose their properties via the new accessors
- extend the generated C header metadata and predicate pushdown test to use the handle-based API

## Testing
- cmake --build build/debug --target test_sql_capi
